### PR TITLE
fix: red border on invalid inputs, stronger signup password rules

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -13,6 +13,7 @@
         "glad_to_see_you": "We are glad to see you! Log in to continue",
         "wrong_email": "Please enter a valid email address",
         "wrong_password": "Password must be at least 6 characters long",
+        "password_weak": "Password must be at least 8 characters and include uppercase, lowercase, a number and a special character",
         "please_sign_up": "Please, Sign Up",
         "greeting": "Welcome! Create an account to continue",
         "confirm_password": "Confirm Password",

--- a/messages/en.json
+++ b/messages/en.json
@@ -12,7 +12,7 @@
         "welcome_back": "Welcome Back",
         "glad_to_see_you": "We are glad to see you! Log in to continue",
         "wrong_email": "Please enter a valid email address",
-        "wrong_password": "Password must be at least 6 characters long",
+        "wrong_password": "Password must be at least 8 characters long",
         "password_weak": "Password must be at least 8 characters and include uppercase, lowercase, a number and a special character",
         "please_sign_up": "Please, Sign Up",
         "greeting": "Welcome! Create an account to continue",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -12,7 +12,7 @@
         "welcome_back": "Witaj ponownie",
         "glad_to_see_you": "Cieszymy się, że jesteś z nami! Zaloguj się, aby kontynuować",
         "wrong_email": "Wprowadź poprawny adres email",
-        "wrong_password": "Hasło musi zawierać co najmniej 6 znaków",
+        "wrong_password": "Hasło musi zawierać co najmniej 8 znaków",
         "password_weak": "Hasło musi mieć co najmniej 8 znaków oraz zawierać wielką literę, małą literę, cyfrę i znak specjalny",
         "please_sign_up": "Proszę, zarejestruj się",
         "greeting": "Witaj! Utwórz konto, aby kontynuować",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -13,6 +13,7 @@
         "glad_to_see_you": "Cieszymy się, że jesteś z nami! Zaloguj się, aby kontynuować",
         "wrong_email": "Wprowadź poprawny adres email",
         "wrong_password": "Hasło musi zawierać co najmniej 6 znaków",
+        "password_weak": "Hasło musi mieć co najmniej 8 znaków oraz zawierać wielką literę, małą literę, cyfrę i znak specjalny",
         "please_sign_up": "Proszę, zarejestruj się",
         "greeting": "Witaj! Utwórz konto, aby kontynuować",
         "confirm_password": "Potwierdź hasło",

--- a/src/components/features/auth/LoginForm.tsx
+++ b/src/components/features/auth/LoginForm.tsx
@@ -81,13 +81,17 @@ export function LoginForm() {
                         <FormField
                             control={form.control}
                             name="email"
-                            render={({ field }) => (
+                            render={({ field, fieldState }) => (
                                 <FormItem>
                                     <FormLabel className="sr-only">{t("email")}</FormLabel>
                                     <FormControl>
                                         <Input
                                             size="default"
-                                            variant="default"
+                                            variant={
+                                                fieldState.error || form.formState.errors.root
+                                                    ? "error"
+                                                    : "default"
+                                            }
                                             type="email"
                                             autoComplete="email"
                                             placeholder={t("email")}
@@ -102,14 +106,18 @@ export function LoginForm() {
                         <FormField
                             control={form.control}
                             name="password"
-                            render={({ field }) => (
+                            render={({ field, fieldState }) => (
                                 <FormItem>
                                     <FormLabel className="sr-only">{t("password")}</FormLabel>
                                     <FormControl>
                                         <div className="relative">
                                             <Input
                                                 size="default"
-                                                variant="default"
+                                                variant={
+                                                    fieldState.error || form.formState.errors.root
+                                                        ? "error"
+                                                        : "default"
+                                                }
                                                 type={showPassword ? "text" : "password"}
                                                 autoComplete="current-password"
                                                 placeholder={t("password")}

--- a/src/components/features/auth/SignupForm.tsx
+++ b/src/components/features/auth/SignupForm.tsx
@@ -45,9 +45,13 @@ export function SignupForm() {
                 email: z.string().email({
                     message: t("wrong_email"),
                 }),
-                password: z.string().min(6, {
-                    message: t("wrong_password"),
-                }),
+                password: z
+                    .string()
+                    .min(8, { message: t("password_weak") })
+                    .regex(/[A-Z]/, { message: t("password_weak") })
+                    .regex(/[a-z]/, { message: t("password_weak") })
+                    .regex(/[0-9]/, { message: t("password_weak") })
+                    .regex(/[^A-Za-z0-9]/, { message: t("password_weak") }),
                 confirmPassword: z.string(),
             })
             .refine((data) => data.password === data.confirmPassword, {

--- a/src/components/features/auth/SignupForm.tsx
+++ b/src/components/features/auth/SignupForm.tsx
@@ -94,13 +94,17 @@ export function SignupForm() {
                         <FormField
                             control={form.control}
                             name="email"
-                            render={({ field }) => (
+                            render={({ field, fieldState }) => (
                                 <FormItem>
                                     <FormLabel className="sr-only">{t("email")}</FormLabel>
                                     <FormControl>
                                         <Input
                                             size="default"
-                                            variant="default"
+                                            variant={
+                                                fieldState.error || form.formState.errors.root
+                                                    ? "error"
+                                                    : "default"
+                                            }
                                             type="email"
                                             autoComplete="email"
                                             placeholder={t("email")}
@@ -115,14 +119,18 @@ export function SignupForm() {
                         <FormField
                             control={form.control}
                             name="password"
-                            render={({ field }) => (
+                            render={({ field, fieldState }) => (
                                 <FormItem>
                                     <FormLabel className="sr-only">{t("password")}</FormLabel>
                                     <FormControl>
                                         <div className="relative">
                                             <Input
                                                 size="default"
-                                                variant="default"
+                                                variant={
+                                                    fieldState.error || form.formState.errors.root
+                                                        ? "error"
+                                                        : "default"
+                                                }
                                                 type={showPassword ? "text" : "password"}
                                                 autoComplete="new-password"
                                                 placeholder={t("password")}
@@ -151,7 +159,7 @@ export function SignupForm() {
                         <FormField
                             control={form.control}
                             name="confirmPassword"
-                            render={({ field }) => (
+                            render={({ field, fieldState }) => (
                                 <FormItem>
                                     <FormLabel className="sr-only">
                                         {t("confirm_password")}
@@ -160,7 +168,11 @@ export function SignupForm() {
                                         <div className="relative">
                                             <Input
                                                 size="default"
-                                                variant="default"
+                                                variant={
+                                                    fieldState.error || form.formState.errors.root
+                                                        ? "error"
+                                                        : "default"
+                                                }
                                                 type={showPasswordConfirm ? "text" : "password"}
                                                 autoComplete="new-password"
                                                 placeholder={t("confirm_password")}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,44 +1,47 @@
 import * as React from "react";
+
 import { cva, type VariantProps } from "class-variance-authority";
+
 import { cn } from "@/lib/utils";
 
 const inputVariants = cva(
-  "flex bg-background ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 w-full text-4 p-3 rounded-none box-border",
-  {
-    variants: {
-      variant: {
-        default: "rounded-none border border-border-input-default text-input-default",
-        outline: "border border-input rounded-md"
-      },
-      size: {
-        default: "w-full px-3 py-4",
-        sm: "h-9 px-3",
-        lg: "h-11 px-8"
-      }
+    "flex bg-background ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 w-full text-4 p-3 rounded-none box-border",
+    {
+        variants: {
+            variant: {
+                default: "rounded-none border border-border-input-default text-input-default",
+                outline: "border border-input rounded-md",
+                error: "rounded-none border border-destructive text-input-default",
+            },
+            size: {
+                default: "w-full px-3 py-4",
+                sm: "h-9 px-3",
+                lg: "h-11 px-8",
+            },
+        },
+        defaultVariants: {
+            variant: "default",
+            size: "default",
+        },
     },
-    defaultVariants: {
-      variant: "default",
-      size: "default"
-    }
-  }
 );
 
 export interface InputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">,
-    VariantProps<typeof inputVariants> {
-}
+    extends
+        Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">,
+        VariantProps<typeof inputVariants> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, variant, size, type, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        className={cn(inputVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
+    ({ className, variant, size, type, ...props }, ref) => {
+        return (
+            <input
+                type={type}
+                className={cn(inputVariants({ variant, size, className }))}
+                ref={ref}
+                {...props}
+            />
+        );
+    },
 );
 Input.displayName = "Input";
 


### PR DESCRIPTION
- Show error variant (red border) on login/signup inputs on field or server errors
- Signup password now requires min 8 chars, uppercase, lowercase, digit and special character
- Add password_weak i18n key in EN and PL